### PR TITLE
Configure Dependabot to run daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,5 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary
- Updates Dependabot schedule from weekly to daily checks

## Benefits
- More frequent dependency updates
- Faster security patch notifications
- Keeps dependencies more current