### PR TITLE
Simplify monitoring to track only card changes

### DIFF
--- a/taskcards_monitor/cli.py
+++ b/taskcards_monitor/cli.py
@@ -47,9 +47,7 @@ def display_changes(changes: dict) -> None:
     if changes.get("is_first_run"):
         console.print(
             Panel(
-                f"[green]Initial state saved[/green]\n"
-                f"Columns: {changes['columns_count']}\n"
-                f"Cards: {changes['cards_count']}",
+                f"[green]Initial state saved[/green]\nCards: {changes['cards_count']}",
                 title="First Run",
                 border_style="green",
             )
@@ -59,14 +57,9 @@ def display_changes(changes: dict) -> None:
     # Check if there are any changes
     has_changes = any(
         [
-            changes["columns_added"],
-            changes["columns_removed"],
-            changes["columns_renamed"],
-            changes["columns_moved"],
             changes["cards_added"],
             changes["cards_removed"],
-            changes["cards_renamed"],
-            changes["cards_moved"],
+            changes["cards_changed"],
         ]
     )
 
@@ -77,127 +70,58 @@ def display_changes(changes: dict) -> None:
     # Display changes
     console.print("\n[bold green]Changes detected:[/bold green]\n")
 
-    # Columns added
-    if changes["columns_added"]:
-        table = create_table(
-            "Columns Added",
-            "bold green",
-            [
-                {"name": "Name", "style": "green"},
-                {"name": "Position", "style": "dim", "justify": "right", "width": 8},
-            ],
-            [(col["name"], str(col["position"])) for col in changes["columns_added"]],
-        )
-        console.print(table)
-        console.print()
-
-    # Columns removed
-    if changes["columns_removed"]:
-        table = create_table(
-            "Columns Removed",
-            "bold red",
-            [
-                {"name": "Name", "style": "red"},
-                {"name": "Position", "style": "dim", "justify": "right", "width": 8},
-            ],
-            [(col["name"], str(col["position"])) for col in changes["columns_removed"]],
-        )
-        console.print(table)
-        console.print()
-
-    # Columns renamed
-    if changes["columns_renamed"]:
-        table = create_table(
-            "Columns Renamed",
-            "bold yellow",
-            [
-                {"name": "Old Name", "style": "dim"},
-                {"name": "New Name", "style": "yellow"},
-                {"name": "Position", "style": "dim", "justify": "right", "width": 8},
-            ],
-            [
-                (col["old_name"], col["new_name"], str(col["position"]))
-                for col in changes["columns_renamed"]
-            ],
-        )
-        console.print(table)
-        console.print()
-
-    # Columns moved (position changed)
-    if changes["columns_moved"]:
-        table = create_table(
-            "Columns Moved",
-            "bold blue",
-            [
-                {"name": "Name", "style": "blue"},
-                {"name": "From", "style": "dim", "justify": "right", "width": 6},
-                {"name": "To", "style": "blue", "justify": "right", "width": 6},
-            ],
-            [
-                (col["name"], str(col["old_position"]), str(col["new_position"]))
-                for col in changes["columns_moved"]
-            ],
-        )
-        console.print(table)
-        console.print()
-
     # Cards added
     if changes["cards_added"]:
-        table = create_table(
-            "Cards Added",
-            "bold green",
-            [{"name": "Title", "style": "green"}, {"name": "Column", "style": "dim"}],
-            [(card["title"], card["column"]) for card in changes["cards_added"]],
-        )
-        console.print(table)
-        console.print()
+        # Show title and description for added cards
+        for card in changes["cards_added"]:
+            console.print(
+                Panel(
+                    f"[bold green]{card['title']}[/bold green]\n\n{card['description'] or '[dim]No description[/dim]'}",
+                    title="Card Added",
+                    border_style="green",
+                )
+            )
+            console.print()
 
     # Cards removed
     if changes["cards_removed"]:
-        table = create_table(
-            "Cards Removed",
-            "bold red",
-            [{"name": "Title", "style": "red"}, {"name": "Column", "style": "dim"}],
-            [(card["title"], card["column"]) for card in changes["cards_removed"]],
-        )
-        console.print(table)
-        console.print()
+        # Show title and description for removed cards
+        for card in changes["cards_removed"]:
+            console.print(
+                Panel(
+                    f"[bold red]{card['title']}[/bold red]\n\n{card['description'] or '[dim]No description[/dim]'}",
+                    title="Card Removed",
+                    border_style="red",
+                )
+            )
+            console.print()
 
-    # Cards renamed
-    if changes["cards_renamed"]:
-        table = create_table(
-            "Cards Renamed",
-            "bold yellow",
-            [
-                {"name": "Old Title", "style": "dim"},
-                {"name": "New Title", "style": "yellow"},
-                {"name": "Column", "style": "dim"},
-            ],
-            [
-                (card["old_title"], card["new_title"], card["column"])
-                for card in changes["cards_renamed"]
-            ],
-        )
-        console.print(table)
-        console.print()
+    # Cards changed
+    if changes["cards_changed"]:
+        # Show title/description changes
+        for card in changes["cards_changed"]:
+            title_changed = card["old_title"] != card["new_title"]
+            desc_changed = card["old_description"] != card["new_description"]
 
-    # Cards moved
-    if changes["cards_moved"]:
-        table = create_table(
-            "Cards Moved",
-            "bold cyan",
-            [
-                {"name": "Title", "style": "cyan"},
-                {"name": "From", "style": "dim"},
-                {"name": "To", "style": "cyan"},
-            ],
-            [
-                (card["title"], card["from_column"], card["to_column"])
-                for card in changes["cards_moved"]
-            ],
-        )
-        console.print(table)
-        console.print()
+            content = ""
+            if title_changed:
+                content += "[bold]Title:[/bold]\n"
+                content += f"[dim]- {card['old_title']}[/dim]\n"
+                content += f"[green]+ {card['new_title']}[/green]\n\n"
+
+            if desc_changed:
+                content += "[bold]Description:[/bold]\n"
+                content += f"[dim]- {card['old_description'] or '(empty)'}[/dim]\n"
+                content += f"[green]+ {card['new_description'] or '(empty)'}[/green]"
+
+            console.print(
+                Panel(
+                    content.strip(),
+                    title="Card Changed",
+                    border_style="yellow",
+                )
+            )
+            console.print()
 
 
 def display_state(state: BoardState) -> None:
@@ -205,40 +129,20 @@ def display_state(state: BoardState) -> None:
 
     console.print(f"\n[bold]Board State[/bold] (saved at {state.timestamp})\n")
 
-    # Display columns
-    if state.columns:
-        table = create_table(
-            "Columns",
-            "bold blue",
-            [{"name": "Name", "style": "blue"}, {"name": "Position", "style": "dim"}],
-            [
-                (col_data["name"], str(col_data["position"]))
-                for _col_id, col_data in sorted(
-                    state.columns.items(), key=lambda x: x[1]["position"]
-                )
-            ],
-        )
-        console.print(table)
-        console.print()
-
     # Display cards
     if state.cards:
-        table = create_table(
-            "Cards",
-            "bold magenta",
-            [{"name": "Title", "style": "magenta"}, {"name": "Column", "style": "dim"}],
-            [
-                (
-                    card_data["title"],
-                    state.columns.get(card_data["column_id"], {}).get("name", "Unknown"),
+        console.print(f"[bold]Total Cards:[/bold] {len(state.cards)}\n")
+        for card_id, card_data in state.cards.items():
+            console.print(
+                Panel(
+                    f"[bold]{card_data['title']}[/bold]\n\n{card_data['description'] or '[dim]No description[/dim]'}",
+                    title=f"Card: {card_id}",
+                    border_style="magenta",
                 )
-                for _card_id, card_data in state.cards.items()
-            ],
-        )
-        console.print(table)
-        console.print()
-
-    console.print(f"[dim]Total: {len(state.columns)} columns, {len(state.cards)} cards[/dim]\n")
+            )
+            console.print()
+    else:
+        console.print("[dim]No cards found[/dim]\n")
 
 
 @click.group()
@@ -440,84 +344,22 @@ def inspect(board_id: str, token: str | None, screenshot: str | None):
 
         # Display detailed statistics
         console.print("[bold]Board Statistics:[/bold]")
-        console.print(f"  Total Columns: {len(state.columns)}")
-        console.print(f"  Total Cards: {len(state.cards)}")
-
-        # Count cards per column
-        cards_per_column = {}
-        for _card_id, card_data in state.cards.items():
-            col_id = card_data["column_id"]
-            cards_per_column[col_id] = cards_per_column.get(col_id, 0) + 1
-
-        console.print(
-            f"  Columns with cards: {len([c for c in cards_per_column.values() if c > 0])}"
-        )
-        console.print(
-            f"  Empty columns: {len(state.columns) - len([c for c in cards_per_column.values() if c > 0])}\n"
-        )
-
-        # Display columns with card counts
-        if state.columns:
-            table = create_table(
-                "Columns Overview",
-                "bold cyan",
-                [
-                    {"name": "Position", "style": "dim", "width": 8},
-                    {"name": "Column Name", "style": "cyan"},
-                    {"name": "Cards", "style": "green", "justify": "right", "width": 6},
-                ],
-                [
-                    (
-                        str(col_data["position"]),
-                        col_data["name"],
-                        str(cards_per_column.get(col_id, 0)),
-                    )
-                    for col_id, col_data in sorted(
-                        state.columns.items(), key=lambda x: x[1]["position"]
-                    )
-                ],
-            )
-            console.print(table)
-            console.print()
+        console.print(f"  Total Cards: {len(state.cards)}\n")
 
         # Display detailed card list
         if state.cards:
-            # Group cards by column and sort
-            cards_by_column = {}
+            console.print(f"[bold]Cards ({len(state.cards)} total):[/bold]\n")
             for card_id, card_data in state.cards.items():
-                col_id = card_data["column_id"]
-                if col_id not in cards_by_column:
-                    cards_by_column[col_id] = []
-                cards_by_column[col_id].append((card_id, card_data))
-
-            # Build rows sorted by column position then card position
-            rows = []
-            for col_id in sorted(state.columns.keys(), key=lambda x: state.columns[x]["position"]):
-                if col_id in cards_by_column:
-                    column_name = state.columns[col_id]["name"]
-                    for _card_id, card_data in sorted(
-                        cards_by_column[col_id], key=lambda x: x[1]["position"] or 0
-                    ):
-                        rows.append(
-                            (
-                                card_data["title"][:60],
-                                column_name,
-                                str(card_data["position"] or "-"),
-                            )
-                        )
-
-            table = create_table(
-                "Cards Detail",
-                "bold magenta",
-                [
-                    {"name": "Card Title", "style": "magenta", "overflow": "fold"},
-                    {"name": "Column", "style": "dim"},
-                    {"name": "Position", "style": "dim", "justify": "right", "width": 8},
-                ],
-                rows,
-            )
-            console.print(table)
-            console.print()
+                console.print(
+                    Panel(
+                        f"[bold]{card_data['title']}[/bold]\n\n{card_data['description'] or '[dim]No description[/dim]'}",
+                        title=f"Card: {card_id}",
+                        border_style="magenta",
+                    )
+                )
+                console.print()
+        else:
+            console.print("[dim]No cards found[/dim]\n")
 
         console.print(
             "[dim italic]Note: This inspection does not affect saved state or monitoring.[/dim italic]\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -192,14 +192,9 @@ class TestCLI:
         # Mock detect_changes to return changes with a new card added
         mock_monitor.detect_changes.return_value = {
             "is_first_run": False,
-            "columns_added": [],
-            "columns_removed": [],
-            "columns_renamed": [],
-            "columns_moved": [],
-            "cards_added": [{"id": "card2", "title": "Task 2", "column": "To Do"}],
+            "cards_added": [{"id": "card2", "title": "Task 2", "description": ""}],
             "cards_removed": [],
-            "cards_renamed": [],
-            "cards_moved": [],
+            "cards_changed": [],
         }
 
         mock_fetcher = MagicMock()
@@ -268,8 +263,8 @@ class TestCLI:
         # Verify
         assert result.exit_code == 0
         assert "Board State" in result.output
-        assert "To Do" in result.output
-        assert "Task 1" in result.output
+        assert "Task 1" in result.output  # Card title should be shown
+        assert "Total Cards" in result.output
 
     @patch("taskcards_monitor.cli.BoardMonitor")
     def test_show_command_no_state(self, mock_monitor_class, runner):
@@ -480,14 +475,9 @@ class TestDisplayFunctions:
 
         changes = {
             "is_first_run": False,
-            "columns_added": [],
-            "columns_removed": [],
-            "columns_renamed": [],
-            "columns_moved": [],
             "cards_added": [],
             "cards_removed": [],
-            "cards_renamed": [],
-            "cards_moved": [],
+            "cards_changed": [],
         }
 
         display_changes(changes)
@@ -515,5 +505,5 @@ class TestDisplayFunctions:
 
         captured = capsys.readouterr()
         assert "Board State" in captured.out
-        assert "To Do" in captured.out
-        assert "Task 1" in captured.out
+        assert "Task 1" in captured.out  # Card title should be shown
+        assert "Total Cards" in captured.out

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -9,194 +9,88 @@ from taskcards_monitor.monitor import BoardMonitor, BoardState
 class TestBoardState:
     """Tests for BoardState class."""
 
-    def test_extract_columns_basic(self):
-        """Test extracting columns from basic board data."""
-        data = {
-            "lists": [
-                {"id": "col1", "name": "To Do", "position": 0, "color": "#ff0000"},
-                {"id": "col2", "name": "In Progress", "position": 1, "color": "#00ff00"},
-                {"id": "col3", "name": "Done", "position": 2, "color": "#0000ff"},
-            ]
-        }
-
-        state = BoardState(data)
-
-        assert len(state.columns) == 3
-        assert state.columns["col1"]["name"] == "To Do"
-        assert state.columns["col1"]["position"] == 0
-        assert state.columns["col1"]["color"] == "#ff0000"
-        assert state.columns["col2"]["name"] == "In Progress"
-        assert state.columns["col3"]["name"] == "Done"
-
-    def test_extract_columns_empty(self):
-        """Test extracting columns when no lists present."""
-        data = {}
-        state = BoardState(data)
-        assert state.columns == {}
-
-    def test_extract_columns_missing_id(self):
-        """Test extracting columns when some lists missing ID."""
-        data = {
-            "lists": [
-                {"id": "col1", "name": "To Do", "position": 0},
-                {"name": "Invalid Column", "position": 1},  # Missing ID
-                {"id": "col2", "name": "Done", "position": 2},
-            ]
-        }
-
-        state = BoardState(data)
-
-        # Should only extract columns with IDs
-        assert len(state.columns) == 2
-        assert "col1" in state.columns
-        assert "col2" in state.columns
-
     def test_extract_cards_basic(self):
-        """Test extracting cards from basic board data."""
+        """Test extracting cards from board data."""
         data = {
             "cards": [
-                {
-                    "id": "card1",
-                    "title": "Task 1",
-                    "description": "Description 1",
-                    "kanbanPosition": {"listId": "col1", "position": 0},
-                },
-                {
-                    "id": "card2",
-                    "title": "Task 2",
-                    "description": "Description 2",
-                    "kanbanPosition": {"listId": "col2", "position": 1},
-                },
-            ]
-        }
-
-        state = BoardState(data)
-
-        assert len(state.cards) == 2
-        assert state.cards["card1"]["title"] == "Task 1"
-        assert state.cards["card1"]["column_id"] == "col1"
-        assert state.cards["card1"]["position"] == 0
-        assert state.cards["card1"]["description"] == "Description 1"
-        assert state.cards["card2"]["column_id"] == "col2"
-
-    def test_extract_cards_empty(self):
-        """Test extracting cards when no cards present."""
-        data = {}
-        state = BoardState(data)
-        assert state.cards == {}
-
-    def test_extract_cards_missing_id(self):
-        """Test extracting cards when some cards missing ID."""
-        data = {
-            "cards": [
-                {
-                    "id": "card1",
-                    "title": "Task 1",
-                    "kanbanPosition": {"listId": "col1", "position": 0},
-                },
-                {
-                    "title": "Invalid Card",  # Missing ID
-                    "kanbanPosition": {"listId": "col2", "position": 1},
-                },
-            ]
-        }
-
-        state = BoardState(data)
-
-        # Should only extract cards with IDs
-        assert len(state.cards) == 1
-        assert "card1" in state.cards
-
-    def test_extract_cards_no_kanban_position(self):
-        """Test extracting cards when kanbanPosition is missing or empty."""
-        data = {
-            "cards": [
-                {
-                    "id": "card1",
-                    "title": "Task 1",
-                    "kanbanPosition": {"listId": "col1", "position": 0},
-                },
-                {
-                    "id": "card2",
-                    "title": "Task 2",
-                    # No kanbanPosition
-                },
-                {
-                    "id": "card3",
-                    "title": "Task 3",
-                    "kanbanPosition": {},  # Empty kanbanPosition
-                },
+                {"id": "card1", "title": "Task 1", "description": "Do this"},
+                {"id": "card2", "title": "Task 2", "description": ""},
+                {"id": "card3", "title": "Task 3", "description": "Do that"},
             ]
         }
 
         state = BoardState(data)
 
         assert len(state.cards) == 3
-        assert state.cards["card1"]["column_id"] == "col1"
-        assert state.cards["card2"]["column_id"] is None
-        assert state.cards["card2"]["position"] is None
-        assert state.cards["card3"]["column_id"] is None
+        assert state.cards["card1"]["title"] == "Task 1"
+        assert state.cards["card1"]["description"] == "Do this"
+        assert state.cards["card2"]["title"] == "Task 2"
+        assert state.cards["card2"]["description"] == ""
 
-    def test_to_dict(self):
-        """Test converting board state to dictionary."""
+    def test_extract_cards_empty(self):
+        """Test extracting cards when none exist."""
+        data = {"cards": []}
+
+        state = BoardState(data)
+
+        assert state.cards == {}
+
+    def test_extract_cards_missing_id(self):
+        """Test extracting cards when some missing IDs."""
         data = {
-            "lists": [{"id": "col1", "name": "To Do", "position": 0}],
             "cards": [
-                {
-                    "id": "card1",
-                    "title": "Task 1",
-                    "kanbanPosition": {"listId": "col1", "position": 0},
-                }
-            ],
+                {"id": "card1", "title": "Task 1", "description": ""},
+                {"title": "Task 2", "description": ""},  # Missing ID
+                {"id": "card3", "title": "Task 3", "description": ""},
+            ]
         }
 
         state = BoardState(data)
-        result = state.to_dict()
 
-        assert "timestamp" in result
-        assert "columns" in result
-        assert "cards" in result
-        assert result["columns"] == state.columns
-        assert result["cards"] == state.cards
+        # Should skip card without ID
+        assert len(state.cards) == 2
+        assert "card1" in state.cards
+        assert "card3" in state.cards
+
+    def test_to_dict(self):
+        """Test converting state to dictionary."""
+        data = {"cards": [{"id": "card1", "title": "Task 1", "description": "Test"}]}
+
+        state = BoardState(data)
+        state_dict = state.to_dict()
+
+        assert "timestamp" in state_dict
+        assert "cards" in state_dict
+        assert state_dict["cards"]["card1"]["title"] == "Task 1"
 
     def test_from_dict(self):
-        """Test creating board state from dictionary."""
+        """Test creating state from dictionary."""
         data = {
-            "timestamp": "2025-01-01T12:00:00",
-            "columns": {"col1": {"name": "To Do", "position": 0, "color": None}},
+            "timestamp": "2023-01-01T00:00:00",
             "cards": {
-                "card1": {
-                    "title": "Task 1",
-                    "column_id": "col1",
-                    "position": 0,
-                    "description": "",
-                }
+                "card1": {"title": "Task 1", "description": "Test"},
             },
         }
 
         state = BoardState.from_dict(data)
 
-        assert state.timestamp == "2025-01-01T12:00:00"
-        assert state.columns == data["columns"]
-        assert state.cards == data["cards"]
-        assert state.raw_data == {}
+        assert state.timestamp == "2023-01-01T00:00:00"
+        assert state.cards["card1"]["title"] == "Task 1"
 
 
 class TestBoardMonitor:
     """Tests for BoardMonitor class."""
 
     def test_init_creates_state_directory(self, tmp_path):
-        """Test that BoardMonitor creates state directory on init."""
+        """Test that init creates state directory."""
         state_dir = tmp_path / "test_state"
         monitor = BoardMonitor("board123", state_dir=state_dir)
 
         assert state_dir.exists()
-        assert state_dir.is_dir()
-        assert monitor.board_id == "board123"
         assert monitor.state_file == state_dir / "board123.json"
 
     def test_init_uses_default_directory(self):
-        """Test that BoardMonitor uses default directory when not specified."""
+        """Test that init uses default directory when none specified."""
         monitor = BoardMonitor("board123")
 
         expected_dir = Path.home() / ".cache" / "taskcards-monitor"
@@ -204,36 +98,27 @@ class TestBoardMonitor:
         assert monitor.state_file == expected_dir / "board123.json"
 
     def test_get_previous_state_no_file(self, tmp_path):
-        """Test getting previous state when no state file exists."""
+        """Test getting previous state when file doesn't exist."""
         monitor = BoardMonitor("board123", state_dir=tmp_path)
+
         state = monitor.get_previous_state()
 
         assert state is None
 
     def test_save_and_load_state(self, tmp_path):
-        """Test saving and loading board state."""
-        monitor = BoardMonitor("board123", state_dir=tmp_path)
+        """Test saving and loading state."""
+        data = {"cards": [{"id": "card1", "title": "Task 1", "description": "Test"}]}
 
-        data = {
-            "lists": [{"id": "col1", "name": "To Do", "position": 0}],
-            "cards": [
-                {
-                    "id": "card1",
-                    "title": "Task 1",
-                    "kanbanPosition": {"listId": "col1", "position": 0},
-                }
-            ],
-        }
+        monitor = BoardMonitor("board123", state_dir=tmp_path)
+        state = BoardState(data)
 
         # Save state
-        state = BoardState(data)
         monitor.save_state(state)
 
         # Load state
         loaded_state = monitor.get_previous_state()
 
         assert loaded_state is not None
-        assert loaded_state.columns == state.columns
         assert loaded_state.cards == state.cards
 
     def test_get_previous_state_corrupted_file(self, tmp_path):
@@ -250,14 +135,9 @@ class TestBoardMonitor:
     def test_detect_changes_first_run(self):
         """Test detecting changes on first run."""
         data = {
-            "lists": [{"id": "col1", "name": "To Do", "position": 0}],
             "cards": [
-                {
-                    "id": "card1",
-                    "title": "Task 1",
-                    "kanbanPosition": {"listId": "col1", "position": 0},
-                }
-            ],
+                {"id": "card1", "title": "Task 1", "description": "Test"},
+            ]
         }
 
         current = BoardState(data)
@@ -265,118 +145,39 @@ class TestBoardMonitor:
         changes = monitor.detect_changes(current, None)
 
         assert changes["is_first_run"] is True
-        assert changes["columns_count"] == 1
         assert changes["cards_count"] == 1
 
     def test_detect_changes_no_changes(self):
         """Test detecting changes when nothing changed."""
         data = {
-            "lists": [{"id": "col1", "name": "To Do", "position": 0}],
             "cards": [
-                {
-                    "id": "card1",
-                    "title": "Task 1",
-                    "kanbanPosition": {"listId": "col1", "position": 0},
-                }
-            ],
+                {"id": "card1", "title": "Task 1", "description": "Test"},
+            ]
         }
 
-        current = BoardState(data)
         previous = BoardState(data)
+        current = BoardState(data)
         monitor = BoardMonitor("board123")
         changes = monitor.detect_changes(current, previous)
 
         assert changes["is_first_run"] is False
-        assert len(changes["columns_added"]) == 0
-        assert len(changes["columns_removed"]) == 0
-        assert len(changes["columns_renamed"]) == 0
         assert len(changes["cards_added"]) == 0
         assert len(changes["cards_removed"]) == 0
-        assert len(changes["cards_moved"]) == 0
-
-    def test_detect_columns_added(self):
-        """Test detecting when columns are added."""
-        prev_data = {"lists": [{"id": "col1", "name": "To Do", "position": 0}]}
-
-        curr_data = {
-            "lists": [
-                {"id": "col1", "name": "To Do", "position": 0},
-                {"id": "col2", "name": "In Progress", "position": 1},
-            ]
-        }
-
-        previous = BoardState(prev_data)
-        current = BoardState(curr_data)
-        monitor = BoardMonitor("board123")
-        changes = monitor.detect_changes(current, previous)
-
-        assert len(changes["columns_added"]) == 1
-        assert changes["columns_added"][0]["id"] == "col2"
-        assert changes["columns_added"][0]["name"] == "In Progress"
-
-    def test_detect_columns_removed(self):
-        """Test detecting when columns are removed."""
-        prev_data = {
-            "lists": [
-                {"id": "col1", "name": "To Do", "position": 0},
-                {"id": "col2", "name": "In Progress", "position": 1},
-            ]
-        }
-
-        curr_data = {"lists": [{"id": "col1", "name": "To Do", "position": 0}]}
-
-        previous = BoardState(prev_data)
-        current = BoardState(curr_data)
-        monitor = BoardMonitor("board123")
-        changes = monitor.detect_changes(current, previous)
-
-        assert len(changes["columns_removed"]) == 1
-        assert changes["columns_removed"][0]["id"] == "col2"
-        assert changes["columns_removed"][0]["name"] == "In Progress"
-
-    def test_detect_columns_renamed(self):
-        """Test detecting when columns are renamed."""
-        prev_data = {"lists": [{"id": "col1", "name": "To Do", "position": 0}]}
-
-        curr_data = {"lists": [{"id": "col1", "name": "TODO", "position": 0}]}
-
-        previous = BoardState(prev_data)
-        current = BoardState(curr_data)
-        monitor = BoardMonitor("board123")
-        changes = monitor.detect_changes(current, previous)
-
-        assert len(changes["columns_renamed"]) == 1
-        assert changes["columns_renamed"][0]["id"] == "col1"
-        assert changes["columns_renamed"][0]["old_name"] == "To Do"
-        assert changes["columns_renamed"][0]["new_name"] == "TODO"
+        assert len(changes["cards_changed"]) == 0
 
     def test_detect_cards_added(self):
         """Test detecting when cards are added."""
         prev_data = {
-            "lists": [{"id": "col1", "name": "To Do", "position": 0}],
             "cards": [
-                {
-                    "id": "card1",
-                    "title": "Task 1",
-                    "kanbanPosition": {"listId": "col1", "position": 0},
-                }
-            ],
+                {"id": "card1", "title": "Task 1", "description": "Test 1"},
+            ]
         }
 
         curr_data = {
-            "lists": [{"id": "col1", "name": "To Do", "position": 0}],
             "cards": [
-                {
-                    "id": "card1",
-                    "title": "Task 1",
-                    "kanbanPosition": {"listId": "col1", "position": 0},
-                },
-                {
-                    "id": "card2",
-                    "title": "Task 2",
-                    "kanbanPosition": {"listId": "col1", "position": 1},
-                },
-            ],
+                {"id": "card1", "title": "Task 1", "description": "Test 1"},
+                {"id": "card2", "title": "Task 2", "description": "Test 2"},
+            ]
         }
 
         previous = BoardState(prev_data)
@@ -387,35 +188,21 @@ class TestBoardMonitor:
         assert len(changes["cards_added"]) == 1
         assert changes["cards_added"][0]["id"] == "card2"
         assert changes["cards_added"][0]["title"] == "Task 2"
-        assert changes["cards_added"][0]["column"] == "To Do"
+        assert changes["cards_added"][0]["description"] == "Test 2"
 
     def test_detect_cards_removed(self):
         """Test detecting when cards are removed."""
         prev_data = {
-            "lists": [{"id": "col1", "name": "To Do", "position": 0}],
             "cards": [
-                {
-                    "id": "card1",
-                    "title": "Task 1",
-                    "kanbanPosition": {"listId": "col1", "position": 0},
-                },
-                {
-                    "id": "card2",
-                    "title": "Task 2",
-                    "kanbanPosition": {"listId": "col1", "position": 1},
-                },
-            ],
+                {"id": "card1", "title": "Task 1", "description": "Test 1"},
+                {"id": "card2", "title": "Task 2", "description": "Test 2"},
+            ]
         }
 
         curr_data = {
-            "lists": [{"id": "col1", "name": "To Do", "position": 0}],
             "cards": [
-                {
-                    "id": "card1",
-                    "title": "Task 1",
-                    "kanbanPosition": {"listId": "col1", "position": 0},
-                }
-            ],
+                {"id": "card1", "title": "Task 1", "description": "Test 1"},
+            ]
         }
 
         previous = BoardState(prev_data)
@@ -426,36 +213,19 @@ class TestBoardMonitor:
         assert len(changes["cards_removed"]) == 1
         assert changes["cards_removed"][0]["id"] == "card2"
         assert changes["cards_removed"][0]["title"] == "Task 2"
-        assert changes["cards_removed"][0]["column"] == "To Do"
 
-    def test_detect_cards_moved(self):
-        """Test detecting when cards are moved between columns."""
+    def test_detect_cards_changed_title(self):
+        """Test detecting when card titles change."""
         prev_data = {
-            "lists": [
-                {"id": "col1", "name": "To Do", "position": 0},
-                {"id": "col2", "name": "Done", "position": 1},
-            ],
             "cards": [
-                {
-                    "id": "card1",
-                    "title": "Task 1",
-                    "kanbanPosition": {"listId": "col1", "position": 0},
-                }
-            ],
+                {"id": "card1", "title": "Old Title", "description": "Test"},
+            ]
         }
 
         curr_data = {
-            "lists": [
-                {"id": "col1", "name": "To Do", "position": 0},
-                {"id": "col2", "name": "Done", "position": 1},
-            ],
             "cards": [
-                {
-                    "id": "card1",
-                    "title": "Task 1",
-                    "kanbanPosition": {"listId": "col2", "position": 0},
-                }
-            ],
+                {"id": "card1", "title": "New Title", "description": "Test"},
+            ]
         }
 
         previous = BoardState(prev_data)
@@ -463,51 +233,49 @@ class TestBoardMonitor:
         monitor = BoardMonitor("board123")
         changes = monitor.detect_changes(current, previous)
 
-        assert len(changes["cards_moved"]) == 1
-        assert changes["cards_moved"][0]["id"] == "card1"
-        assert changes["cards_moved"][0]["title"] == "Task 1"
-        assert changes["cards_moved"][0]["from_column"] == "To Do"
-        assert changes["cards_moved"][0]["to_column"] == "Done"
+        assert len(changes["cards_changed"]) == 1
+        assert changes["cards_changed"][0]["id"] == "card1"
+        assert changes["cards_changed"][0]["old_title"] == "Old Title"
+        assert changes["cards_changed"][0]["new_title"] == "New Title"
+
+    def test_detect_cards_changed_description(self):
+        """Test detecting when card descriptions change."""
+        prev_data = {
+            "cards": [
+                {"id": "card1", "title": "Task 1", "description": "Old description"},
+            ]
+        }
+
+        curr_data = {
+            "cards": [
+                {"id": "card1", "title": "Task 1", "description": "New description"},
+            ]
+        }
+
+        previous = BoardState(prev_data)
+        current = BoardState(curr_data)
+        monitor = BoardMonitor("board123")
+        changes = monitor.detect_changes(current, previous)
+
+        assert len(changes["cards_changed"]) == 1
+        assert changes["cards_changed"][0]["old_description"] == "Old description"
+        assert changes["cards_changed"][0]["new_description"] == "New description"
 
     def test_detect_multiple_changes(self):
         """Test detecting multiple types of changes at once."""
         prev_data = {
-            "lists": [
-                {"id": "col1", "name": "To Do", "position": 0},
-                {"id": "col2", "name": "Done", "position": 1},
-            ],
             "cards": [
-                {
-                    "id": "card1",
-                    "title": "Task 1",
-                    "kanbanPosition": {"listId": "col1", "position": 0},
-                },
-                {
-                    "id": "card2",
-                    "title": "Task 2",
-                    "kanbanPosition": {"listId": "col1", "position": 1},
-                },
-            ],
+                {"id": "card1", "title": "Task 1", "description": "Test 1"},
+                {"id": "card2", "title": "Task 2", "description": "Test 2"},
+            ]
         }
 
         curr_data = {
-            "lists": [
-                {"id": "col1", "name": "TODO", "position": 0},  # Renamed
-                {"id": "col3", "name": "In Progress", "position": 1},  # Added
-            ],
             "cards": [
-                {
-                    "id": "card1",
-                    "title": "Task 1",
-                    "kanbanPosition": {"listId": "col3", "position": 0},  # Moved
-                },
-                {
-                    "id": "card3",
-                    "title": "Task 3",
-                    "kanbanPosition": {"listId": "col1", "position": 0},  # Added
-                },
+                {"id": "card1", "title": "Task 1 Updated", "description": "Test 1"},  # Changed
+                {"id": "card3", "title": "Task 3", "description": "Test 3"},  # Added
                 # card2 removed
-            ],
+            ]
         }
 
         previous = BoardState(prev_data)
@@ -516,9 +284,6 @@ class TestBoardMonitor:
         changes = monitor.detect_changes(current, previous)
 
         # Check all types of changes detected
-        assert len(changes["columns_added"]) == 1  # col3
-        assert len(changes["columns_removed"]) == 1  # col2
-        assert len(changes["columns_renamed"]) == 1  # col1
         assert len(changes["cards_added"]) == 1  # card3
         assert len(changes["cards_removed"]) == 1  # card2
-        assert len(changes["cards_moved"]) == 1  # card1
+        assert len(changes["cards_changed"]) == 1  # card1

--- a/uv.lock
+++ b/uv.lock
@@ -296,42 +296,44 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.3.4"
+version = "9.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
+    { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919, upload-time = "2024-12-01T12:54:25.98Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/56/f013048ac4bc4c1d9be45afd4ab209ea62822fb1598f40687e6bf45dcea4/pytest-9.0.1.tar.gz", hash = "sha256:3e9c069ea73583e255c3b21cf46b8d3c56f6e3a1a8f6da94ccb0fcf57b9d73c8", size = 1564125, upload-time = "2025-11-12T13:05:09.333Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083, upload-time = "2024-12-01T12:54:19.735Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/8b/6300fb80f858cda1c51ffa17075df5d846757081d11ab4aa35cef9e6258b/pytest-9.0.1-py3-none-any.whl", hash = "sha256:67be0030d194df2dfa7b556f2e56fb3c3315bd5c8822c6951162b92b32ce7dad", size = 373668, upload-time = "2025-11-12T13:05:07.379Z" },
 ]
 
 [[package]]
 name = "pytest-cov"
-version = "6.0.0"
+version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "coverage" },
+    { name = "pluggy" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/be/45/9b538de8cef30e17c7b45ef42f538a94889ed6a16f2387a6c89e73220651/pytest-cov-6.0.0.tar.gz", hash = "sha256:fde0b595ca248bb8e2d76f020b465f3b107c9632e6a1d1705f17834c89dcadc0", size = 66945, upload-time = "2024-10-29T20:13:35.363Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/3b/48e79f2cd6a61dbbd4807b4ed46cb564b4fd50a76166b1c4ea5c1d9e2371/pytest_cov-6.0.0-py3-none-any.whl", hash = "sha256:eee6f1b9e61008bd34975a4d5bab25801eb31898b032dd55addc93e96fcaaa35", size = 22949, upload-time = "2024-10-29T20:13:33.215Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
 ]
 
 [[package]]
 name = "pytest-mock"
-version = "3.14.0"
+version = "3.15.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/90/a955c3ab35ccd41ad4de556596fa86685bf4fc5ffcc62d22d856cfd4e29a/pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0", size = 32814, upload-time = "2024-03-21T22:14:04.964Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/3b/b26f90f74e2986a82df6e7ac7e319b8ea7ccece1caec9f8ab6104dc70603/pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f", size = 9863, upload-time = "2024-03-21T22:14:02.694Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
 ]
 
 [[package]]
@@ -448,9 +450,9 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pre-commit", specifier = "==4.5.0" },
-    { name = "pytest", specifier = "==8.3.4" },
-    { name = "pytest-cov", specifier = "==6.0.0" },
-    { name = "pytest-mock", specifier = "==3.14.0" },
+    { name = "pytest", specifier = "==9.0.1" },
+    { name = "pytest-cov", specifier = "==7.0.0" },
+    { name = "pytest-mock", specifier = "==3.15.1" },
     { name = "ruff", specifier = "==0.14.6" },
 ]
 


### PR DESCRIPTION
## Summary

Simplified the monitoring tool to focus only on card content changes, removing all the complexity around column tracking and card movements.

## What Changed

**Now tracks only:**
- ✅ Cards added (new card IDs)
- ✅ Cards removed (missing card IDs)
- ✅ Cards changed (title or description modified)

**Removed:**
- ❌ Column tracking (added, removed, renamed, moved)
- ❌ Card movement tracking between columns
- ❌ Card position tracking within columns
- ❌ Complex rename detection logic

## Implementation Details

- Reduced `monitor.py` from 469 lines to 187 lines (~60% reduction)
- Removed column extraction entirely from `BoardState`
- Simplified `detect_changes()` to only compare card IDs and content
- Updated CLI to display card content in panels with diff-style formatting
- Rewrote all tests to match the simplified structure
- Test coverage: 90%

## Display Improvements

**Before:** Tables showing card titles and column names  
**After:** Rich panels showing full card content including descriptions

Changed cards now show clear diff-style output:
```
Title:
- Old Title
+ New Title

Description:
- Old description
+ New description
```

## Benefits

- **Simpler:** Much easier to understand and maintain
- **Focused:** Only tracks what matters - card content
- **Cleaner:** Better visual display of card changes
- **Tested:** All 52 tests passing with 90% coverage

## Related

- Archived full change tracking implementation in `archive/full-change-tracking` branch
- Can reference that branch if more detailed tracking is needed in the future