### PR TITLE
Simplify to card-only tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # taskcards-monitor
 
-Monitor [TaskCards](https://www.taskcards.de) boards for changes (added/removed cards and columns) using browser automation.
+Monitor [TaskCards](https://www.taskcards.de) boards for card changes using browser automation.
 
 ## Features
 
 - Monitor both **public and private** TaskCards boards
 - Detect added/removed cards
-- Detect added/removed/renamed columns
-- Track card movements between columns
+- Detect card title changes
 - Uses Playwright browser automation
 - Persistent state tracking
 
@@ -101,21 +100,21 @@ TaskCards is a client-side rendered application that requires JavaScript to load
 When changes are detected:
 
 ```
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃            Cards Added                      ┃
-┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-┃ Title                    │ Column           ┃
-├──────────────────────────┼──────────────────┤
-│ New homework assignment  │ Organisatorisches│
-└──────────────────────────┴──────────────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃            Cards Added                ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+┃ Title                                 ┃
+├───────────────────────────────────────┤
+│ New homework assignment               │
+└───────────────────────────────────────┘
 
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃            Cards Moved                    ┃
-┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-┃ Title           │ From      │ To          ┃
-├─────────────────┼───────────┼─────────────┤
-│ Old assignment  │ Termine   │ Aktuelles   │
-└─────────────────┴───────────┴─────────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃            Cards Changed                      ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+┃ Old Title       │ New Title                   ┃
+├─────────────────┼─────────────────────────────┤
+│ Old assignment  │ Updated assignment details  │
+└─────────────────┴─────────────────────────────┘
 ```
 
 ## Troubleshooting
@@ -188,7 +187,7 @@ taskcards_monitor/
 Planned features (not yet implemented):
 - Email notifications
 - Change history tracking
-- Diff view for card content changes
+- Track card descriptions and other metadata
 
 ## Contributing
 

--- a/taskcards_monitor/cli.py
+++ b/taskcards_monitor/cli.py
@@ -47,9 +47,7 @@ def display_changes(changes: dict) -> None:
     if changes.get("is_first_run"):
         console.print(
             Panel(
-                f"[green]Initial state saved[/green]\n"
-                f"Columns: {changes['columns_count']}\n"
-                f"Cards: {changes['cards_count']}",
+                f"[green]Initial state saved[/green]\nCards: {changes['cards_count']}",
                 title="First Run",
                 border_style="green",
             )
@@ -59,12 +57,9 @@ def display_changes(changes: dict) -> None:
     # Check if there are any changes
     has_changes = any(
         [
-            changes["columns_added"],
-            changes["columns_removed"],
-            changes["columns_renamed"],
             changes["cards_added"],
             changes["cards_removed"],
-            changes["cards_moved"],
+            changes["cards_changed"],
         ]
     )
 
@@ -75,46 +70,13 @@ def display_changes(changes: dict) -> None:
     # Display changes
     console.print("\n[bold green]Changes detected:[/bold green]\n")
 
-    # Columns added
-    if changes["columns_added"]:
-        table = create_table(
-            "Columns Added",
-            "bold green",
-            [{"name": "Name", "style": "green"}],
-            [(col["name"],) for col in changes["columns_added"]],
-        )
-        console.print(table)
-        console.print()
-
-    # Columns removed
-    if changes["columns_removed"]:
-        table = create_table(
-            "Columns Removed",
-            "bold red",
-            [{"name": "Name", "style": "red"}],
-            [(col["name"],) for col in changes["columns_removed"]],
-        )
-        console.print(table)
-        console.print()
-
-    # Columns renamed
-    if changes["columns_renamed"]:
-        table = create_table(
-            "Columns Renamed",
-            "bold yellow",
-            [{"name": "Old Name", "style": "dim"}, {"name": "New Name", "style": "yellow"}],
-            [(col["old_name"], col["new_name"]) for col in changes["columns_renamed"]],
-        )
-        console.print(table)
-        console.print()
-
     # Cards added
     if changes["cards_added"]:
         table = create_table(
             "Cards Added",
             "bold green",
-            [{"name": "Title", "style": "green"}, {"name": "Column", "style": "dim"}],
-            [(card["title"], card["column"]) for card in changes["cards_added"]],
+            [{"name": "Title", "style": "green"}],
+            [(card["title"],) for card in changes["cards_added"]],
         )
         console.print(table)
         console.print()
@@ -124,26 +86,19 @@ def display_changes(changes: dict) -> None:
         table = create_table(
             "Cards Removed",
             "bold red",
-            [{"name": "Title", "style": "red"}, {"name": "Column", "style": "dim"}],
-            [(card["title"], card["column"]) for card in changes["cards_removed"]],
+            [{"name": "Title", "style": "red"}],
+            [(card["title"],) for card in changes["cards_removed"]],
         )
         console.print(table)
         console.print()
 
-    # Cards moved
-    if changes["cards_moved"]:
+    # Cards changed
+    if changes["cards_changed"]:
         table = create_table(
-            "Cards Moved",
-            "bold cyan",
-            [
-                {"name": "Title", "style": "cyan"},
-                {"name": "From", "style": "dim"},
-                {"name": "To", "style": "cyan"},
-            ],
-            [
-                (card["title"], card["from_column"], card["to_column"])
-                for card in changes["cards_moved"]
-            ],
+            "Cards Changed",
+            "bold yellow",
+            [{"name": "Old Title", "style": "dim"}, {"name": "New Title", "style": "yellow"}],
+            [(card["old_title"], card["new_title"]) for card in changes["cards_changed"]],
         )
         console.print(table)
         console.print()
@@ -154,40 +109,20 @@ def display_state(state: BoardState) -> None:
 
     console.print(f"\n[bold]Board State[/bold] (saved at {state.timestamp})\n")
 
-    # Display columns
-    if state.columns:
-        table = create_table(
-            "Columns",
-            "bold blue",
-            [{"name": "Name", "style": "blue"}, {"name": "Position", "style": "dim"}],
-            [
-                (col_data["name"], str(col_data["position"]))
-                for _col_id, col_data in sorted(
-                    state.columns.items(), key=lambda x: x[1]["position"]
-                )
-            ],
-        )
-        console.print(table)
-        console.print()
-
     # Display cards
     if state.cards:
         table = create_table(
             "Cards",
             "bold magenta",
-            [{"name": "Title", "style": "magenta"}, {"name": "Column", "style": "dim"}],
-            [
-                (
-                    card_data["title"],
-                    state.columns.get(card_data["column_id"], {}).get("name", "Unknown"),
-                )
-                for _card_id, card_data in state.cards.items()
-            ],
+            [{"name": "Title", "style": "magenta"}],
+            [(card_data["title"],) for _card_id, card_data in state.cards.items()],
         )
         console.print(table)
         console.print()
+    else:
+        console.print("[dim]No cards found[/dim]\n")
 
-    console.print(f"[dim]Total: {len(state.columns)} columns, {len(state.cards)} cards[/dim]\n")
+    console.print(f"[dim]Total: {len(state.cards)} cards[/dim]\n")
 
 
 @click.group()
@@ -303,14 +238,12 @@ def list_boards():
             with open(state_file) as f:
                 data = json.load(f)
                 timestamp = data.get("timestamp", "Unknown")
-                columns_count = len(data.get("columns", {}))
                 cards_count = len(data.get("cards", {}))
 
                 boards_info.append(
                     {
                         "board_id": board_id,
                         "timestamp": timestamp,
-                        "columns": columns_count,
                         "cards": cards_count,
                     }
                 )
@@ -330,14 +263,12 @@ def list_boards():
         [
             {"name": "Board ID", "style": "cyan"},
             {"name": "Last Checked", "style": "dim"},
-            {"name": "Columns", "style": "green", "justify": "right"},
             {"name": "Cards", "style": "magenta", "justify": "right"},
         ],
         [
             (
                 board["board_id"],
                 board["timestamp"],
-                str(board["columns"]),
                 str(board["cards"]),
             )
             for board in boards_info
@@ -389,84 +320,20 @@ def inspect(board_id: str, token: str | None, screenshot: str | None):
 
         # Display detailed statistics
         console.print("[bold]Board Statistics:[/bold]")
-        console.print(f"  Total Columns: {len(state.columns)}")
-        console.print(f"  Total Cards: {len(state.cards)}")
-
-        # Count cards per column
-        cards_per_column = {}
-        for _card_id, card_data in state.cards.items():
-            col_id = card_data["column_id"]
-            cards_per_column[col_id] = cards_per_column.get(col_id, 0) + 1
-
-        console.print(
-            f"  Columns with cards: {len([c for c in cards_per_column.values() if c > 0])}"
-        )
-        console.print(
-            f"  Empty columns: {len(state.columns) - len([c for c in cards_per_column.values() if c > 0])}\n"
-        )
-
-        # Display columns with card counts
-        if state.columns:
-            table = create_table(
-                "Columns Overview",
-                "bold cyan",
-                [
-                    {"name": "Position", "style": "dim", "width": 8},
-                    {"name": "Column Name", "style": "cyan"},
-                    {"name": "Cards", "style": "green", "justify": "right", "width": 6},
-                ],
-                [
-                    (
-                        str(col_data["position"]),
-                        col_data["name"],
-                        str(cards_per_column.get(col_id, 0)),
-                    )
-                    for col_id, col_data in sorted(
-                        state.columns.items(), key=lambda x: x[1]["position"]
-                    )
-                ],
-            )
-            console.print(table)
-            console.print()
+        console.print(f"  Total Cards: {len(state.cards)}\n")
 
         # Display detailed card list
         if state.cards:
-            # Group cards by column and sort
-            cards_by_column = {}
-            for card_id, card_data in state.cards.items():
-                col_id = card_data["column_id"]
-                if col_id not in cards_by_column:
-                    cards_by_column[col_id] = []
-                cards_by_column[col_id].append((card_id, card_data))
-
-            # Build rows sorted by column position then card position
-            rows = []
-            for col_id in sorted(state.columns.keys(), key=lambda x: state.columns[x]["position"]):
-                if col_id in cards_by_column:
-                    column_name = state.columns[col_id]["name"]
-                    for _card_id, card_data in sorted(
-                        cards_by_column[col_id], key=lambda x: x[1]["position"] or 0
-                    ):
-                        rows.append(
-                            (
-                                card_data["title"][:60],
-                                column_name,
-                                str(card_data["position"] or "-"),
-                            )
-                        )
-
             table = create_table(
-                "Cards Detail",
+                "Cards",
                 "bold magenta",
-                [
-                    {"name": "Card Title", "style": "magenta", "overflow": "fold"},
-                    {"name": "Column", "style": "dim"},
-                    {"name": "Position", "style": "dim", "justify": "right", "width": 8},
-                ],
-                rows,
+                [{"name": "Card Title", "style": "magenta", "overflow": "fold"}],
+                [(card_data["title"],) for _card_id, card_data in state.cards.items()],
             )
             console.print(table)
             console.print()
+        else:
+            console.print("[dim]No cards found[/dim]\n")
 
         console.print(
             "[dim italic]Note: This inspection does not affect saved state or monitoring.[/dim italic]\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -192,12 +192,9 @@ class TestCLI:
         # Mock detect_changes to return changes with a new card added
         mock_monitor.detect_changes.return_value = {
             "is_first_run": False,
-            "columns_added": [],
-            "columns_removed": [],
-            "columns_renamed": [],
-            "cards_added": [{"id": "card2", "title": "Task 2", "column": "To Do"}],
+            "cards_added": [{"id": "card2", "title": "Task 2"}],
             "cards_removed": [],
-            "cards_moved": [],
+            "cards_changed": [],
         }
 
         mock_fetcher = MagicMock()
@@ -245,15 +242,10 @@ class TestCLI:
 
         # Create board state
         data = {
-            "lists": [
-                {"id": "col1", "name": "To Do", "position": 0},
-                {"id": "col2", "name": "Done", "position": 1},
-            ],
             "cards": [
                 {
                     "id": "card1",
                     "title": "Task 1",
-                    "kanbanPosition": {"listId": "col1", "position": 0},
                 }
             ],
         }
@@ -266,7 +258,6 @@ class TestCLI:
         # Verify
         assert result.exit_code == 0
         assert "Board State" in result.output
-        assert "To Do" in result.output
         assert "Task 1" in result.output
 
     @patch("taskcards_monitor.cli.BoardMonitor")
@@ -478,12 +469,9 @@ class TestDisplayFunctions:
 
         changes = {
             "is_first_run": False,
-            "columns_added": [],
-            "columns_removed": [],
-            "columns_renamed": [],
             "cards_added": [],
             "cards_removed": [],
-            "cards_moved": [],
+            "cards_changed": [],
         }
 
         display_changes(changes)
@@ -496,12 +484,10 @@ class TestDisplayFunctions:
         from taskcards_monitor.cli import display_state
 
         data = {
-            "lists": [{"id": "col1", "name": "To Do", "position": 0}],
             "cards": [
                 {
                     "id": "card1",
                     "title": "Task 1",
-                    "kanbanPosition": {"listId": "col1", "position": 0},
                 }
             ],
         }
@@ -511,5 +497,4 @@ class TestDisplayFunctions:
 
         captured = capsys.readouterr()
         assert "Board State" in captured.out
-        assert "To Do" in captured.out
         assert "Task 1" in captured.out

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -9,48 +9,6 @@ from taskcards_monitor.monitor import BoardMonitor, BoardState
 class TestBoardState:
     """Tests for BoardState class."""
 
-    def test_extract_columns_basic(self):
-        """Test extracting columns from basic board data."""
-        data = {
-            "lists": [
-                {"id": "col1", "name": "To Do", "position": 0, "color": "#ff0000"},
-                {"id": "col2", "name": "In Progress", "position": 1, "color": "#00ff00"},
-                {"id": "col3", "name": "Done", "position": 2, "color": "#0000ff"},
-            ]
-        }
-
-        state = BoardState(data)
-
-        assert len(state.columns) == 3
-        assert state.columns["col1"]["name"] == "To Do"
-        assert state.columns["col1"]["position"] == 0
-        assert state.columns["col1"]["color"] == "#ff0000"
-        assert state.columns["col2"]["name"] == "In Progress"
-        assert state.columns["col3"]["name"] == "Done"
-
-    def test_extract_columns_empty(self):
-        """Test extracting columns when no lists present."""
-        data = {}
-        state = BoardState(data)
-        assert state.columns == {}
-
-    def test_extract_columns_missing_id(self):
-        """Test extracting columns when some lists missing ID."""
-        data = {
-            "lists": [
-                {"id": "col1", "name": "To Do", "position": 0},
-                {"name": "Invalid Column", "position": 1},  # Missing ID
-                {"id": "col2", "name": "Done", "position": 2},
-            ]
-        }
-
-        state = BoardState(data)
-
-        # Should only extract columns with IDs
-        assert len(state.columns) == 2
-        assert "col1" in state.columns
-        assert "col2" in state.columns
-
     def test_extract_cards_basic(self):
         """Test extracting cards from basic board data."""
         data = {
@@ -74,10 +32,7 @@ class TestBoardState:
 
         assert len(state.cards) == 2
         assert state.cards["card1"]["title"] == "Task 1"
-        assert state.cards["card1"]["column_id"] == "col1"
-        assert state.cards["card1"]["position"] == 0
-        assert state.cards["card1"]["description"] == "Description 1"
-        assert state.cards["card2"]["column_id"] == "col2"
+        assert state.cards["card2"]["title"] == "Task 2"
 
     def test_extract_cards_empty(self):
         """Test extracting cards when no cards present."""
@@ -107,45 +62,13 @@ class TestBoardState:
         assert len(state.cards) == 1
         assert "card1" in state.cards
 
-    def test_extract_cards_no_kanban_position(self):
-        """Test extracting cards when kanbanPosition is missing or empty."""
-        data = {
-            "cards": [
-                {
-                    "id": "card1",
-                    "title": "Task 1",
-                    "kanbanPosition": {"listId": "col1", "position": 0},
-                },
-                {
-                    "id": "card2",
-                    "title": "Task 2",
-                    # No kanbanPosition
-                },
-                {
-                    "id": "card3",
-                    "title": "Task 3",
-                    "kanbanPosition": {},  # Empty kanbanPosition
-                },
-            ]
-        }
-
-        state = BoardState(data)
-
-        assert len(state.cards) == 3
-        assert state.cards["card1"]["column_id"] == "col1"
-        assert state.cards["card2"]["column_id"] is None
-        assert state.cards["card2"]["position"] is None
-        assert state.cards["card3"]["column_id"] is None
-
     def test_to_dict(self):
         """Test converting board state to dictionary."""
         data = {
-            "lists": [{"id": "col1", "name": "To Do", "position": 0}],
             "cards": [
                 {
                     "id": "card1",
                     "title": "Task 1",
-                    "kanbanPosition": {"listId": "col1", "position": 0},
                 }
             ],
         }
@@ -154,22 +77,16 @@ class TestBoardState:
         result = state.to_dict()
 
         assert "timestamp" in result
-        assert "columns" in result
         assert "cards" in result
-        assert result["columns"] == state.columns
         assert result["cards"] == state.cards
 
     def test_from_dict(self):
         """Test creating board state from dictionary."""
         data = {
             "timestamp": "2025-01-01T12:00:00",
-            "columns": {"col1": {"name": "To Do", "position": 0, "color": None}},
             "cards": {
                 "card1": {
                     "title": "Task 1",
-                    "column_id": "col1",
-                    "position": 0,
-                    "description": "",
                 }
             },
         }
@@ -177,7 +94,6 @@ class TestBoardState:
         state = BoardState.from_dict(data)
 
         assert state.timestamp == "2025-01-01T12:00:00"
-        assert state.columns == data["columns"]
         assert state.cards == data["cards"]
         assert state.raw_data == {}
 
@@ -215,12 +131,10 @@ class TestBoardMonitor:
         monitor = BoardMonitor("board123", state_dir=tmp_path)
 
         data = {
-            "lists": [{"id": "col1", "name": "To Do", "position": 0}],
             "cards": [
                 {
                     "id": "card1",
                     "title": "Task 1",
-                    "kanbanPosition": {"listId": "col1", "position": 0},
                 }
             ],
         }
@@ -233,7 +147,6 @@ class TestBoardMonitor:
         loaded_state = monitor.get_previous_state()
 
         assert loaded_state is not None
-        assert loaded_state.columns == state.columns
         assert loaded_state.cards == state.cards
 
     def test_get_previous_state_corrupted_file(self, tmp_path):
@@ -250,12 +163,10 @@ class TestBoardMonitor:
     def test_detect_changes_first_run(self):
         """Test detecting changes on first run."""
         data = {
-            "lists": [{"id": "col1", "name": "To Do", "position": 0}],
             "cards": [
                 {
                     "id": "card1",
                     "title": "Task 1",
-                    "kanbanPosition": {"listId": "col1", "position": 0},
                 }
             ],
         }
@@ -265,18 +176,15 @@ class TestBoardMonitor:
         changes = monitor.detect_changes(current, None)
 
         assert changes["is_first_run"] is True
-        assert changes["columns_count"] == 1
         assert changes["cards_count"] == 1
 
     def test_detect_changes_no_changes(self):
         """Test detecting changes when nothing changed."""
         data = {
-            "lists": [{"id": "col1", "name": "To Do", "position": 0}],
             "cards": [
                 {
                     "id": "card1",
                     "title": "Task 1",
-                    "kanbanPosition": {"listId": "col1", "position": 0},
                 }
             ],
         }
@@ -287,94 +195,30 @@ class TestBoardMonitor:
         changes = monitor.detect_changes(current, previous)
 
         assert changes["is_first_run"] is False
-        assert len(changes["columns_added"]) == 0
-        assert len(changes["columns_removed"]) == 0
-        assert len(changes["columns_renamed"]) == 0
         assert len(changes["cards_added"]) == 0
         assert len(changes["cards_removed"]) == 0
-        assert len(changes["cards_moved"]) == 0
-
-    def test_detect_columns_added(self):
-        """Test detecting when columns are added."""
-        prev_data = {"lists": [{"id": "col1", "name": "To Do", "position": 0}]}
-
-        curr_data = {
-            "lists": [
-                {"id": "col1", "name": "To Do", "position": 0},
-                {"id": "col2", "name": "In Progress", "position": 1},
-            ]
-        }
-
-        previous = BoardState(prev_data)
-        current = BoardState(curr_data)
-        monitor = BoardMonitor("board123")
-        changes = monitor.detect_changes(current, previous)
-
-        assert len(changes["columns_added"]) == 1
-        assert changes["columns_added"][0]["id"] == "col2"
-        assert changes["columns_added"][0]["name"] == "In Progress"
-
-    def test_detect_columns_removed(self):
-        """Test detecting when columns are removed."""
-        prev_data = {
-            "lists": [
-                {"id": "col1", "name": "To Do", "position": 0},
-                {"id": "col2", "name": "In Progress", "position": 1},
-            ]
-        }
-
-        curr_data = {"lists": [{"id": "col1", "name": "To Do", "position": 0}]}
-
-        previous = BoardState(prev_data)
-        current = BoardState(curr_data)
-        monitor = BoardMonitor("board123")
-        changes = monitor.detect_changes(current, previous)
-
-        assert len(changes["columns_removed"]) == 1
-        assert changes["columns_removed"][0]["id"] == "col2"
-        assert changes["columns_removed"][0]["name"] == "In Progress"
-
-    def test_detect_columns_renamed(self):
-        """Test detecting when columns are renamed."""
-        prev_data = {"lists": [{"id": "col1", "name": "To Do", "position": 0}]}
-
-        curr_data = {"lists": [{"id": "col1", "name": "TODO", "position": 0}]}
-
-        previous = BoardState(prev_data)
-        current = BoardState(curr_data)
-        monitor = BoardMonitor("board123")
-        changes = monitor.detect_changes(current, previous)
-
-        assert len(changes["columns_renamed"]) == 1
-        assert changes["columns_renamed"][0]["id"] == "col1"
-        assert changes["columns_renamed"][0]["old_name"] == "To Do"
-        assert changes["columns_renamed"][0]["new_name"] == "TODO"
+        assert len(changes["cards_changed"]) == 0
 
     def test_detect_cards_added(self):
         """Test detecting when cards are added."""
         prev_data = {
-            "lists": [{"id": "col1", "name": "To Do", "position": 0}],
             "cards": [
                 {
                     "id": "card1",
                     "title": "Task 1",
-                    "kanbanPosition": {"listId": "col1", "position": 0},
                 }
             ],
         }
 
         curr_data = {
-            "lists": [{"id": "col1", "name": "To Do", "position": 0}],
             "cards": [
                 {
                     "id": "card1",
                     "title": "Task 1",
-                    "kanbanPosition": {"listId": "col1", "position": 0},
                 },
                 {
                     "id": "card2",
                     "title": "Task 2",
-                    "kanbanPosition": {"listId": "col1", "position": 1},
                 },
             ],
         }
@@ -387,33 +231,27 @@ class TestBoardMonitor:
         assert len(changes["cards_added"]) == 1
         assert changes["cards_added"][0]["id"] == "card2"
         assert changes["cards_added"][0]["title"] == "Task 2"
-        assert changes["cards_added"][0]["column"] == "To Do"
 
     def test_detect_cards_removed(self):
         """Test detecting when cards are removed."""
         prev_data = {
-            "lists": [{"id": "col1", "name": "To Do", "position": 0}],
             "cards": [
                 {
                     "id": "card1",
                     "title": "Task 1",
-                    "kanbanPosition": {"listId": "col1", "position": 0},
                 },
                 {
                     "id": "card2",
                     "title": "Task 2",
-                    "kanbanPosition": {"listId": "col1", "position": 1},
                 },
             ],
         }
 
         curr_data = {
-            "lists": [{"id": "col1", "name": "To Do", "position": 0}],
             "cards": [
                 {
                     "id": "card1",
                     "title": "Task 1",
-                    "kanbanPosition": {"listId": "col1", "position": 0},
                 }
             ],
         }
@@ -426,34 +264,23 @@ class TestBoardMonitor:
         assert len(changes["cards_removed"]) == 1
         assert changes["cards_removed"][0]["id"] == "card2"
         assert changes["cards_removed"][0]["title"] == "Task 2"
-        assert changes["cards_removed"][0]["column"] == "To Do"
 
-    def test_detect_cards_moved(self):
-        """Test detecting when cards are moved between columns."""
+    def test_detect_cards_changed(self):
+        """Test detecting when cards have their title changed."""
         prev_data = {
-            "lists": [
-                {"id": "col1", "name": "To Do", "position": 0},
-                {"id": "col2", "name": "Done", "position": 1},
-            ],
             "cards": [
                 {
                     "id": "card1",
                     "title": "Task 1",
-                    "kanbanPosition": {"listId": "col1", "position": 0},
                 }
             ],
         }
 
         curr_data = {
-            "lists": [
-                {"id": "col1", "name": "To Do", "position": 0},
-                {"id": "col2", "name": "Done", "position": 1},
-            ],
             "cards": [
                 {
                     "id": "card1",
-                    "title": "Task 1",
-                    "kanbanPosition": {"listId": "col2", "position": 0},
+                    "title": "Updated Task 1",
                 }
             ],
         }
@@ -463,48 +290,35 @@ class TestBoardMonitor:
         monitor = BoardMonitor("board123")
         changes = monitor.detect_changes(current, previous)
 
-        assert len(changes["cards_moved"]) == 1
-        assert changes["cards_moved"][0]["id"] == "card1"
-        assert changes["cards_moved"][0]["title"] == "Task 1"
-        assert changes["cards_moved"][0]["from_column"] == "To Do"
-        assert changes["cards_moved"][0]["to_column"] == "Done"
+        assert len(changes["cards_changed"]) == 1
+        assert changes["cards_changed"][0]["id"] == "card1"
+        assert changes["cards_changed"][0]["old_title"] == "Task 1"
+        assert changes["cards_changed"][0]["new_title"] == "Updated Task 1"
 
     def test_detect_multiple_changes(self):
         """Test detecting multiple types of changes at once."""
         prev_data = {
-            "lists": [
-                {"id": "col1", "name": "To Do", "position": 0},
-                {"id": "col2", "name": "Done", "position": 1},
-            ],
             "cards": [
                 {
                     "id": "card1",
                     "title": "Task 1",
-                    "kanbanPosition": {"listId": "col1", "position": 0},
                 },
                 {
                     "id": "card2",
                     "title": "Task 2",
-                    "kanbanPosition": {"listId": "col1", "position": 1},
                 },
             ],
         }
 
         curr_data = {
-            "lists": [
-                {"id": "col1", "name": "TODO", "position": 0},  # Renamed
-                {"id": "col3", "name": "In Progress", "position": 1},  # Added
-            ],
             "cards": [
                 {
                     "id": "card1",
-                    "title": "Task 1",
-                    "kanbanPosition": {"listId": "col3", "position": 0},  # Moved
+                    "title": "Updated Task 1",  # Changed
                 },
                 {
                     "id": "card3",
-                    "title": "Task 3",
-                    "kanbanPosition": {"listId": "col1", "position": 0},  # Added
+                    "title": "Task 3",  # Added
                 },
                 # card2 removed
             ],
@@ -516,9 +330,6 @@ class TestBoardMonitor:
         changes = monitor.detect_changes(current, previous)
 
         # Check all types of changes detected
-        assert len(changes["columns_added"]) == 1  # col3
-        assert len(changes["columns_removed"]) == 1  # col2
-        assert len(changes["columns_renamed"]) == 1  # col1
         assert len(changes["cards_added"]) == 1  # card3
         assert len(changes["cards_removed"]) == 1  # card2
-        assert len(changes["cards_moved"]) == 1  # card1
+        assert len(changes["cards_changed"]) == 1  # card1


### PR DESCRIPTION
Remove column change tracking and focus solely on card changes:
- Track only card additions, removals, and title changes
- Remove column tracking logic from monitor.py
- Simplify CLI output to show only card-related changes
- Update all tests to reflect simplified tracking
- Update README and CLAUDE.md documentation

This simplification makes the tool easier to maintain and more focused on its core purpose of tracking card changes.