### PR TITLE
refactor: Extract display logic from CLI into dedicated module

### DIFF
--- a/taskcards_monitor/cli.py
+++ b/taskcards_monitor/cli.py
@@ -5,174 +5,17 @@ from importlib.metadata import version
 from pathlib import Path
 
 import click
-from rich.console import Console
-from rich.panel import Panel
-from rich.table import Table
 
+from .display import (
+    console,
+    display_boards_list,
+    display_changes,
+    display_inspect_header,
+    display_inspect_results,
+    display_state,
+)
 from .fetcher import TaskCardsFetcher
 from .monitor import BoardMonitor, BoardState
-
-console = Console()
-
-
-def create_table(title: str, header_style: str, columns: list[dict], rows: list) -> Table:
-    """Create a Rich table with the given configuration.
-
-    Args:
-        title: Table title
-        header_style: Style for table headers
-        columns: List of column configs with 'name', 'style', etc.
-        rows: List of row data (tuples/lists matching column count)
-
-    Returns:
-        Configured Rich Table
-    """
-    table = Table(title=title, show_header=True, header_style=header_style)
-    for col in columns:
-        table.add_column(
-            col["name"],
-            style=col.get("style", ""),
-            width=col.get("width"),
-            justify=col.get("justify", "left"),
-            overflow=col.get("overflow", "ellipsis"),
-        )
-    for row in rows:
-        table.add_row(*row)
-    return table
-
-
-def display_changes(changes: dict) -> None:
-    """Display detected changes with beautiful formatting."""
-
-    if changes.get("is_first_run"):
-        console.print(
-            Panel(
-                f"[green]Initial state saved[/green]\nCards: {changes['cards_count']}",
-                title="First Run",
-                border_style="green",
-            )
-        )
-        return
-
-    # Check if there are any changes
-    has_changes = any(
-        [
-            changes["cards_added"],
-            changes["cards_removed"],
-            changes["cards_changed"],
-        ]
-    )
-
-    if not has_changes:
-        console.print(Panel("[dim]No changes detected[/dim]", title="Status", border_style="blue"))
-        return
-
-    # Display changes
-    console.print("\n[bold green]Changes detected:[/bold green]\n")
-
-    # Cards added
-    if changes["cards_added"]:
-        table = create_table(
-            "Cards Added",
-            "bold green",
-            [
-                {"name": "Title", "style": "green"},
-                {"name": "Description", "style": "green dim", "width": 50, "overflow": "fold"},
-            ],
-            [
-                (card["title"], card["description"] or "[dim]<empty>[/dim]")
-                for card in changes["cards_added"]
-            ],
-        )
-        console.print(table)
-        console.print()
-
-    # Cards removed
-    if changes["cards_removed"]:
-        table = create_table(
-            "Cards Removed",
-            "bold red",
-            [
-                {"name": "Title", "style": "red"},
-                {"name": "Description", "style": "red dim", "width": 50, "overflow": "fold"},
-            ],
-            [
-                (card["title"], card["description"] or "[dim]<empty>[/dim]")
-                for card in changes["cards_removed"]
-            ],
-        )
-        console.print(table)
-        console.print()
-
-    # Cards changed
-    if changes["cards_changed"]:
-        rows = []
-        for card in changes["cards_changed"]:
-            # Determine what changed
-            title_changed = card["old_title"] != card["new_title"]
-            desc_changed = card["old_description"] != card["new_description"]
-
-            if title_changed and desc_changed:
-                change_type = "Title & Description"
-            elif title_changed:
-                change_type = "Title"
-            else:
-                change_type = "Description"
-
-            old_desc = card["old_description"] or "[dim]<empty>[/dim]"
-            new_desc = card["new_description"] or "[dim]<empty>[/dim]"
-
-            rows.append(
-                (
-                    change_type,
-                    card["old_title"] if title_changed else "[dim]unchanged[/dim]",
-                    card["new_title"] if title_changed else "[dim]unchanged[/dim]",
-                    old_desc if desc_changed else "[dim]unchanged[/dim]",
-                    new_desc if desc_changed else "[dim]unchanged[/dim]",
-                )
-            )
-
-        table = create_table(
-            "Cards Changed",
-            "bold yellow",
-            [
-                {"name": "Changed", "style": "yellow", "width": 15},
-                {"name": "Old Title", "style": "dim", "width": 25, "overflow": "fold"},
-                {"name": "New Title", "style": "yellow", "width": 25, "overflow": "fold"},
-                {"name": "Old Description", "style": "dim", "width": 30, "overflow": "fold"},
-                {"name": "New Description", "style": "yellow", "width": 30, "overflow": "fold"},
-            ],
-            rows,
-        )
-        console.print(table)
-        console.print()
-
-
-def display_state(state: BoardState) -> None:
-    """Display the current board state."""
-
-    console.print(f"\n[bold]Board State[/bold] (saved at {state.timestamp})\n")
-
-    # Display cards
-    if state.cards:
-        table = create_table(
-            "Cards",
-            "bold magenta",
-            [
-                {"name": "Title", "style": "magenta", "width": 30},
-                {"name": "Description", "style": "magenta dim", "width": 60, "overflow": "fold"},
-            ],
-            [
-                (card_data["title"], card_data["description"] or "[dim]<empty>[/dim]")
-                for _card_id, card_data in state.cards.items()
-            ],
-        )
-        console.print(table)
-        console.print()
-    else:
-        console.print("[dim]No cards found[/dim]\n")
-
-    console.print(f"[dim]Total: {len(state.cards)} cards[/dim]\n")
 
 
 @click.group()
@@ -306,29 +149,7 @@ def list_boards():
         return
 
     # Display the boards table
-    console.print()
-    table = create_table(
-        f"Monitored Boards ({len(boards_info)} total)",
-        "bold blue",
-        [
-            {"name": "Board ID", "style": "cyan"},
-            {"name": "Last Checked", "style": "dim"},
-            {"name": "Cards", "style": "magenta", "justify": "right"},
-        ],
-        [
-            (
-                board["board_id"],
-                board["timestamp"],
-                str(board["cards"]),
-            )
-            for board in boards_info
-        ],
-    )
-    console.print(table)
-    console.print()
-    console.print(
-        "[dim]Tip: Use 'taskcards-monitor show BOARD_ID' to see detailed state for a specific board[/dim]\n"
-    )
+    display_boards_list(boards_info)
 
 
 @main.command()
@@ -346,59 +167,19 @@ def inspect(board_id: str, token: str | None, screenshot: str | None):
     - Keeps browser open briefly for manual inspection
     """
 
-    console.print(
-        Panel(
-            f"[bold cyan]Board ID:[/bold cyan] {board_id}\n"
-            f"[dim]This is a debugging tool - state will NOT be saved[/dim]",
-            title="Inspect Mode",
-            border_style="cyan",
-        )
-    )
+    display_inspect_header(board_id)
 
     try:
         console.print("\n[cyan]Opening browser (visible mode)...[/cyan]")
 
         with TaskCardsFetcher(headless=False) as fetcher:
             data = fetcher.fetch_board(board_id, token=token, screenshot_path=screenshot)
-            if screenshot:
-                console.print(f"\n[green]✓ Screenshot saved to:[/green] {screenshot}")
 
         # Create state for display
         state = BoardState(data)
 
-        console.print("\n[green]✓ Board loaded successfully![/green]\n")
-
-        # Display detailed statistics
-        console.print("[bold]Board Statistics:[/bold]")
-        console.print(f"  Total Cards: {len(state.cards)}\n")
-
-        # Display detailed card list
-        if state.cards:
-            table = create_table(
-                "Cards",
-                "bold magenta",
-                [
-                    {"name": "Card Title", "style": "magenta", "width": 30, "overflow": "fold"},
-                    {
-                        "name": "Description",
-                        "style": "magenta dim",
-                        "width": 60,
-                        "overflow": "fold",
-                    },
-                ],
-                [
-                    (card_data["title"], card_data["description"] or "[dim]<empty>[/dim]")
-                    for _card_id, card_data in state.cards.items()
-                ],
-            )
-            console.print(table)
-            console.print()
-        else:
-            console.print("[dim]No cards found[/dim]\n")
-
-        console.print(
-            "[dim italic]Note: This inspection does not affect saved state or monitoring.[/dim italic]\n"
-        )
+        # Display results
+        display_inspect_results(state, screenshot)
 
     except Exception as e:
         console.print(f"\n[bold red]Error:[/bold red] {str(e)}")

--- a/taskcards_monitor/display.py
+++ b/taskcards_monitor/display.py
@@ -1,0 +1,251 @@
+"""Display utilities for TaskCards monitor output."""
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from .monitor import BoardState
+
+console = Console()
+
+
+def create_table(title: str, header_style: str, columns: list[dict], rows: list) -> Table:
+    """Create a Rich table with the given configuration.
+
+    Args:
+        title: Table title
+        header_style: Style for table headers
+        columns: List of column configs with 'name', 'style', etc.
+        rows: List of row data (tuples/lists matching column count)
+
+    Returns:
+        Configured Rich Table
+    """
+    table = Table(title=title, show_header=True, header_style=header_style)
+    for col in columns:
+        table.add_column(
+            col["name"],
+            style=col.get("style", ""),
+            width=col.get("width"),
+            justify=col.get("justify", "left"),
+            overflow=col.get("overflow", "ellipsis"),
+        )
+    for row in rows:
+        table.add_row(*row)
+    return table
+
+
+def display_changes(changes: dict) -> None:
+    """Display detected changes with beautiful formatting."""
+
+    if changes.get("is_first_run"):
+        console.print(
+            Panel(
+                f"[green]Initial state saved[/green]\nCards: {changes['cards_count']}",
+                title="First Run",
+                border_style="green",
+            )
+        )
+        return
+
+    # Check if there are any changes
+    has_changes = any(
+        [
+            changes["cards_added"],
+            changes["cards_removed"],
+            changes["cards_changed"],
+        ]
+    )
+
+    if not has_changes:
+        console.print(Panel("[dim]No changes detected[/dim]", title="Status", border_style="blue"))
+        return
+
+    # Display changes
+    console.print("\n[bold green]Changes detected:[/bold green]\n")
+
+    # Cards added
+    if changes["cards_added"]:
+        table = create_table(
+            "Cards Added",
+            "bold green",
+            [
+                {"name": "Title", "style": "green"},
+                {"name": "Description", "style": "green dim", "width": 50, "overflow": "fold"},
+            ],
+            [
+                (card["title"], card["description"] or "[dim]<empty>[/dim]")
+                for card in changes["cards_added"]
+            ],
+        )
+        console.print(table)
+        console.print()
+
+    # Cards removed
+    if changes["cards_removed"]:
+        table = create_table(
+            "Cards Removed",
+            "bold red",
+            [
+                {"name": "Title", "style": "red"},
+                {"name": "Description", "style": "red dim", "width": 50, "overflow": "fold"},
+            ],
+            [
+                (card["title"], card["description"] or "[dim]<empty>[/dim]")
+                for card in changes["cards_removed"]
+            ],
+        )
+        console.print(table)
+        console.print()
+
+    # Cards changed
+    if changes["cards_changed"]:
+        rows = []
+        for card in changes["cards_changed"]:
+            # Determine what changed
+            title_changed = card["old_title"] != card["new_title"]
+            desc_changed = card["old_description"] != card["new_description"]
+
+            if title_changed and desc_changed:
+                change_type = "Title & Description"
+            elif title_changed:
+                change_type = "Title"
+            else:
+                change_type = "Description"
+
+            old_desc = card["old_description"] or "[dim]<empty>[/dim]"
+            new_desc = card["new_description"] or "[dim]<empty>[/dim]"
+
+            rows.append(
+                (
+                    change_type,
+                    card["old_title"] if title_changed else "[dim]unchanged[/dim]",
+                    card["new_title"] if title_changed else "[dim]unchanged[/dim]",
+                    old_desc if desc_changed else "[dim]unchanged[/dim]",
+                    new_desc if desc_changed else "[dim]unchanged[/dim]",
+                )
+            )
+
+        table = create_table(
+            "Cards Changed",
+            "bold yellow",
+            [
+                {"name": "Changed", "style": "yellow", "width": 15},
+                {"name": "Old Title", "style": "dim", "width": 25, "overflow": "fold"},
+                {"name": "New Title", "style": "yellow", "width": 25, "overflow": "fold"},
+                {"name": "Old Description", "style": "dim", "width": 30, "overflow": "fold"},
+                {"name": "New Description", "style": "yellow", "width": 30, "overflow": "fold"},
+            ],
+            rows,
+        )
+        console.print(table)
+        console.print()
+
+
+def display_state(state: BoardState) -> None:
+    """Display the current board state."""
+
+    console.print(f"\n[bold]Board State[/bold] (saved at {state.timestamp})\n")
+
+    # Display cards
+    if state.cards:
+        table = create_table(
+            "Cards",
+            "bold magenta",
+            [
+                {"name": "Title", "style": "magenta", "width": 30},
+                {"name": "Description", "style": "magenta dim", "width": 60, "overflow": "fold"},
+            ],
+            [
+                (card_data["title"], card_data["description"] or "[dim]<empty>[/dim]")
+                for _card_id, card_data in state.cards.items()
+            ],
+        )
+        console.print(table)
+        console.print()
+    else:
+        console.print("[dim]No cards found[/dim]\n")
+
+    console.print(f"[dim]Total: {len(state.cards)} cards[/dim]\n")
+
+
+def display_boards_list(boards_info: list[dict]) -> None:
+    """Display a table of monitored boards."""
+
+    console.print()
+    table = create_table(
+        f"Monitored Boards ({len(boards_info)} total)",
+        "bold blue",
+        [
+            {"name": "Board ID", "style": "cyan"},
+            {"name": "Last Checked", "style": "dim"},
+            {"name": "Cards", "style": "magenta", "justify": "right"},
+        ],
+        [
+            (
+                board["board_id"],
+                board["timestamp"],
+                str(board["cards"]),
+            )
+            for board in boards_info
+        ],
+    )
+    console.print(table)
+    console.print()
+    console.print(
+        "[dim]Tip: Use 'taskcards-monitor show BOARD_ID' to see detailed state for a specific board[/dim]\n"
+    )
+
+
+def display_inspect_header(board_id: str) -> None:
+    """Display header for inspect mode."""
+
+    console.print(
+        Panel(
+            f"[bold cyan]Board ID:[/bold cyan] {board_id}\n"
+            f"[dim]This is a debugging tool - state will NOT be saved[/dim]",
+            title="Inspect Mode",
+            border_style="cyan",
+        )
+    )
+
+
+def display_inspect_results(state: BoardState, screenshot_path: str | None) -> None:
+    """Display results from board inspection."""
+
+    if screenshot_path:
+        console.print(f"\n[green]✓ Screenshot saved to:[/green] {screenshot_path}")
+
+    console.print("\n[green]✓ Board loaded successfully![/green]\n")
+
+    # Display detailed statistics
+    console.print("[bold]Board Statistics:[/bold]")
+    console.print(f"  Total Cards: {len(state.cards)}\n")
+
+    # Display detailed card list
+    if state.cards:
+        table = create_table(
+            "Cards",
+            "bold magenta",
+            [
+                {"name": "Card Title", "style": "magenta", "width": 30, "overflow": "fold"},
+                {
+                    "name": "Description",
+                    "style": "magenta dim",
+                    "width": 60,
+                    "overflow": "fold",
+                },
+            ],
+            [
+                (card_data["title"], card_data["description"] or "[dim]<empty>[/dim]")
+                for _card_id, card_data in state.cards.items()
+            ],
+        )
+        console.print(table)
+        console.print()
+    else:
+        console.print("[dim]No cards found[/dim]\n")
+
+    console.print(
+        "[dim italic]Note: This inspection does not affect saved state or monitoring.[/dim italic]\n"
+    )


### PR DESCRIPTION
Separates presentation logic from CLI command handling by moving all Rich console formatting functions to a new display.py module.

Changes:
- Created taskcards_monitor/display.py with all display functions
- Moved create_table(), display_changes(), display_state() to display.py
- Added display_boards_list() for the list command output
- Added display_inspect_header() and display_inspect_results() for inspect command
- Updated cli.py to import and use display functions
- Removed unused Console import from cli.py