### PR TITLE
fix(email): Use BCC to protect recipient privacy

### DIFF
--- a/taskcards_monitor/email_notifier.py
+++ b/taskcards_monitor/email_notifier.py
@@ -153,7 +153,9 @@ class EmailNotifier:
             if self.config.from_name
             else self.config.from_email
         )
-        msg["To"] = ", ".join(self.config.to_emails)
+        # Use Bcc to hide recipients from each other
+        msg["To"] = self.config.from_email
+        msg["Bcc"] = ", ".join(self.config.to_emails)
 
         # Attach HTML content
         html_part = MIMEText(html_content, "html")


### PR DESCRIPTION
Email notifications now use BCC instead of exposing all recipient addresses in the To field. This prevents recipients from seeing each other's email addresses.

The To field is now set to the sender's email address, while all actual recipients are added to the Bcc field for privacy.

Fixes #58