### PR TITLE
Add conditional board link in email and TaskCards.de footer link

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "taskcards-monitor"
-version = "0.5.0"
+version = "0.5.1"
 description = "Monitor TaskCards boards for changes using GraphQL API"
 requires-python = ">=3.12"
 dependencies = [

--- a/taskcards_monitor/cli.py
+++ b/taskcards_monitor/cli.py
@@ -93,6 +93,7 @@ def check(board_id: str, token: str | None, verbose: bool, email_config: Path | 
                 board_name=current_state.board_name,
                 timestamp=current_state.timestamp,
                 changes=changes,
+                token=token,
             )
 
             if email_sent:

--- a/taskcards_monitor/email_notifier.py
+++ b/taskcards_monitor/email_notifier.py
@@ -73,6 +73,7 @@ class EmailNotifier:
         board_name: str | None,
         timestamp: str,
         changes: dict[str, Any],
+        token: str | None = None,
     ) -> bool:
         """Send email notification if there are changes (not on first run).
 
@@ -81,6 +82,7 @@ class EmailNotifier:
             board_name: The board name (optional)
             timestamp: Timestamp of the check
             changes: Changes dictionary from BoardMonitor.detect_changes()
+            token: View token for private boards (optional)
 
         Returns:
             True if email was sent, False otherwise
@@ -103,6 +105,7 @@ class EmailNotifier:
             added_cards=changes["cards_added"],
             removed_cards=changes["cards_removed"],
             changed_cards=changes["cards_changed"],
+            token=token,
         )
 
         return True
@@ -115,6 +118,7 @@ class EmailNotifier:
         added_cards: list[dict[str, Any]],
         removed_cards: list[dict[str, Any]],
         changed_cards: list[dict[str, Any]],
+        token: str | None = None,
     ) -> None:
         """Send email notification about board changes.
 
@@ -125,11 +129,18 @@ class EmailNotifier:
             added_cards: List of added cards
             removed_cards: List of removed cards
             changed_cards: List of changed cards
+            token: View token for private boards (optional)
         """
+        # Construct board URL (only for public boards without token)
+        board_url = None
+        if not token:
+            board_url = f"https://www.taskcards.de/#/board/{board_id}/view"
+
         # Prepare template context
         context = {
             "board_id": board_id,
             "board_name": board_name or board_id,
+            "board_url": board_url,
             "timestamp": timestamp,
             "added_cards": added_cards,
             "removed_cards": removed_cards,

--- a/taskcards_monitor/email_template.html
+++ b/taskcards_monitor/email_template.html
@@ -96,6 +96,10 @@
 
     <div class="board-info">
         <strong>Checked at:</strong> {{ timestamp }}
+        {% if board_url %}
+        <br>
+        <strong>Board Link:</strong> <a href="{{ board_url }}" style="color: #3498db;">{{ board_url }}</a>
+        {% endif %}
     </div>
 
     <div class="summary">
@@ -273,7 +277,8 @@
         <p>This email was sent by <strong>taskcards-monitor v{{ version }}</strong>, an open source TaskCards monitoring tool.</p>
         <p>
             🔗 <a href="https://github.com/molecode/taskcards-monitor" style="color: #3498db;">GitHub Repository</a> |
-            🐛 <a href="https://github.com/molecode/taskcards-monitor/issues" style="color: #3498db;">Issue Tracker</a>
+            🐛 <a href="https://github.com/molecode/taskcards-monitor/issues" style="color: #3498db;">Issue Tracker</a> |
+            📋 <a href="https://www.taskcards.de" style="color: #3498db;">TaskCards.de</a>
         </p>
         <p style="margin-top: 10px; font-size: 11px;">Board: {{ board_name }} ({{ board_id }})</p>
     </div>


### PR DESCRIPTION
## Summary
- Show board link in email only for public boards (without view token)
- Add TaskCards.de link in email footer alongside GitHub links  
- Pass token information to email notifier for URL construction
- Bump version to 0.5.1

## Changes
- Modified `email_notifier.py` to accept token parameter and construct board URL conditionally
- Updated `cli.py` to pass token to the email notifier
- Enhanced email template to display board link below timestamp when board is public
- Added TaskCards.de link to email footer
- Updated version from 0.5.0 to 0.5.1

## Behavior
For **public boards** (no token), the email will display a direct link to the board below the timestamp:
```
Checked at: 2025-12-20 10:30:45
Board Link: https://www.taskcards.de/#/board/BOARD_ID/view
```

For **private boards** (with token), the board link is omitted to prevent exposing the view token in emails.

All emails now include a general link to https://www.taskcards.de in the footer.

## Test plan
- [x] Test with public board (no token) - verify board link appears in email
- [x] Test with private board (with token) - verify board link is omitted
- [x] Verify TaskCards.de link appears in footer for all emails
- [x] Verify version bump to 0.5.1