### PR TITLE
Fix Docker build by including README.md

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -36,6 +36,7 @@ htmlcov/
 
 # Documentation
 *.md
+!README.md
 docs/
 
 # Development

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN addgroup -S taskcards && \
     chown -R taskcards:taskcards /app
 
 # Copy application files
-COPY --chown=taskcards:taskcards pyproject.toml uv.lock ./
+COPY --chown=taskcards:taskcards pyproject.toml uv.lock README.md ./
 COPY --chown=taskcards:taskcards taskcards_monitor/ ./taskcards_monitor/
 
 # Switch to non-root user before installing


### PR DESCRIPTION
## Summary
- Fix Docker build failure caused by missing README.md file

## Problem
The Docker build was failing with:
```
OSError: Readme file does not exist: README.md
```

This occurred because `pyproject.toml` references `README.md` as package metadata, but:
1. The `.dockerignore` file excluded all `*.md` files
2. The `Dockerfile` wasn't explicitly copying `README.md`

## Changes
- Added `!README.md` exception to `.dockerignore` to allow README in build context
- Updated `Dockerfile` to explicitly copy `README.md` into the container

## Test plan
- [x] Docker build completes successfully: `docker build -t taskcards-monitor:test .`
- [x] Package builds without errors
- [ ] Review changes
- [ ] Merge to main